### PR TITLE
Completed log rotation by file size

### DIFF
--- a/WNC_expressjs/logger.js
+++ b/WNC_expressjs/logger.js
@@ -1,5 +1,6 @@
 import { createLogger, format, transports } from "winston";
 import { default as pm2_io } from "@pm2/io";
+import DailyRotateFile from "winston-daily-rotate-file";
 
 const logger = createLogger({
   level: "debug",
@@ -10,6 +11,13 @@ const logger = createLogger({
   transports: [
     new transports.Console({ consoleWarnLevels: ["error"], level: "error" }),
     new transports.File({ filename: "./logs/error.log", level: "error" }),
+    new DailyRotateFile({
+      filename: "./logs/%DATE%/application-%DATE%.log",
+      datePattern: "YYYY-MM-DD",
+      zippedArchive: true,
+      maxSize: "2m",
+      maxFiles: "14d"
+    })
   ],
 });
 

--- a/WNC_expressjs/package.json
+++ b/WNC_expressjs/package.json
@@ -20,6 +20,7 @@
     "swagger-jsdoc": "^6.2.8",
     "swagger-ui-express": "^5.0.0",
     "winston": "^3.11.0",
+    "winston-daily-rotate-file": "^4.7.1",
     "zod": "^3.22.4",
     "zod-to-json-schema": "^3.21.4"
   },

--- a/WNC_expressjs/src/routes/api/actors.js
+++ b/WNC_expressjs/src/routes/api/actors.js
@@ -156,7 +156,7 @@ actors_router.patch("/:id", async function (req, res) {
   return res.status(200).json(data);
 });
 
-actors_router.delete("/:id", async function (req, res) {
+actors_router.delete("/:id", async function (req, res, next) {
   const { id } = req.params;
   if (!id) {
     return res.status(400).json({ error: "Missing id!" });
@@ -165,7 +165,7 @@ actors_router.delete("/:id", async function (req, res) {
   const [data, err] = await CallAndCatchAsync(DeleteAnActor, { id });
 
   if (err) {
-    return res.status(500).json({ msg: "Server error!", error: err });
+    next(err)
   }
 
   return res.status(200).json(data);

--- a/WNC_expressjs/src/routes/api/films.js
+++ b/WNC_expressjs/src/routes/api/films.js
@@ -141,7 +141,7 @@ films_router.delete(
     });
 
     if (err) {
-      return res.status(500).json({ msg: "Server error!", error: err });
+      next(err)
     }
 
     return res.status(200).json(data);


### PR DESCRIPTION
To test this feature, please follow these steps:
- Go to _logger.js_ to change config of maxSize of transport DailyRotateFile to '2k' (or small enough to see logging file split)
- Go to [localhost:3085/api-docs](url) and try to create some requests logged by winstonLogger (you can turn off the connection to db) that lead to error
- See result in path _logs/%DATE%/application-%DATE%.log_